### PR TITLE
fix incorrect xml in junit report

### DIFF
--- a/include/nonius/reporters/junit_reporter.h++
+++ b/include/nonius/reporters/junit_reporter.h++
@@ -98,9 +98,9 @@ namespace nonius {
             report_stream() << ">\n";
 
             report_stream() << " <properties>\n";
-            report_stream() << "  <property name=\"samples\" value=\"" << n_samples << "\">\n";
-            report_stream() << "  <property name=\"confidence_interval\" value=\"" << std::setprecision(3) << confidence_interval << "\">\n";
-            report_stream() << "  <property name=\"resamples\" value=\"" << resamples << "\">\n";
+            report_stream() << "  <property name=\"samples\" value=\"" << n_samples << "\" />\n";
+            report_stream() << "  <property name=\"confidence_interval\" value=\"" << std::setprecision(3) << confidence_interval << "\" />\n";
+            report_stream() << "  <property name=\"resamples\" value=\"" << resamples << "\" />\n";
             report_stream() << " </properties>\n";
 
             for(auto tc : data) {
@@ -154,4 +154,3 @@ namespace nonius {
 } // namespace nonius
 
 #endif // NONIUS_REPORTERS_JUNIT_REPORTER_HPP
-


### PR DESCRIPTION
The output of --reporter=junit is not parseable by some xml parsers due to error in <property> item.
Merge request is proposed to fix that problem.