### PR TITLE
Add messages to argument_error

### DIFF
--- a/include/nonius/detail/argparse.h++
+++ b/include/nonius/detail/argparse.h++
@@ -24,6 +24,7 @@
 #include <iomanip>
 #include <tuple>
 #include <functional>
+#include <stdexcept>
 
 namespace nonius {
     namespace detail {
@@ -97,7 +98,9 @@ namespace nonius {
 
         using arguments = std::unordered_multimap<std::string, std::string>;
 
-        struct argument_error {
+        struct argument_error : public std::logic_error {
+            using std::logic_error::logic_error;
+
             virtual ~argument_error() = default;
         };
 
@@ -107,7 +110,7 @@ namespace nonius {
                 if(++first != last) {
                     args.emplace(o.long_form, *first);
                 } else {
-                    throw argument_error();
+                    throw argument_error{"Iterator mismatch in parse_short"};
                 }
             } else {
                 args.emplace(o.long_form, "");
@@ -135,7 +138,8 @@ namespace nonius {
                     }
                 }
                 if(!parsed) {
-                    throw argument_error();
+                    throw argument_error{"Option " + *first +
+                        " does not match any short or long options from options_set"};
                 }
             }
             return args;

--- a/include/nonius/main.h++
+++ b/include/nonius/main.h++
@@ -85,7 +85,7 @@ namespace nonius {
                     if(is_valid(value)) {
                         std::forward<Assignment>(assign) (variable, std::move(value));
                     } else {
-                        throw argument_error();
+                        throw argument_error{"Tried to parse invalid value"};
                     }
                 }
             }
@@ -149,12 +149,17 @@ namespace nonius {
                 parse(cfg.verbose, args, "verbose");
                 parse(cfg.summary, args, "summary");
                 parse(cfg.title, args, "title");
-                if(cfg.verbose && cfg.summary) throw argument_error();
+                if(cfg.verbose && cfg.summary)
+                    throw argument_error{"Verbose and summary output are mutually exclusive"};
 
                 return cfg;
+            } catch (const argument_error& ae) {
+                std::cout << "Argument error: " << ae.what() << std::endl
+                          << help_text(name, command_line_options());
+                throw;
             } catch(...) {
                 std::cout << help_text(name, command_line_options());
-                throw argument_error();
+                throw argument_error{"Unexpected catch in argument parsing"};
             }
         }
     } // namespace detail


### PR DESCRIPTION
The `argument_error` struct is used as an exception object, but it has no means to report details of the error. This PR makes `argument_error` a public inheritor of `std::logic_error`, inheriting its constructors. Descriptive messages are also added wherever `argument_error` may be thrown.
